### PR TITLE
Update the scraper to match the new markup as of the 2023.04.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ENV DISPLAY=:99
 RUN pip install --upgrade pip
 
 # install selenium
-RUN pip install selenium bs4 pandas youtube-dl
+RUN pip install selenium==3.141.0 bs4 pandas youtube-dl
 
 # essentia music extractor
 RUN wget ftp://ftp.acousticbrainz.org/pub/acousticbrainz/essentia-extractor-v2.1_beta2-linux-x86_64.tar.gz

--- a/scraper.py
+++ b/scraper.py
@@ -84,7 +84,7 @@ class Scraper():
             btn.send_keys(keys.Keys.SPACE)
 
             soup = BeautifulSoup(self.driver.page_source, features='html.parser')
-            voting_grid = soup.find('div', {'id': 'voting_grid'})
+            voting_grid = soup.find('table', {'class': 'scoreboard_table'})
 
         if len(voting_grid.text) > 0:
 
@@ -107,7 +107,7 @@ class Scraper():
                 country_id = cols[2]['data-to']
                 # total_points = cols[3].text
 
-                points_cols = cols[4:]
+                points_cols = cols[4:-1]
                 for p in points_cols:
                     from_country_id = p['data-from']
                     to_country_id = p['data-to']


### PR DESCRIPTION
> selenium==3.141.0

It was done because Selenium 4.3.0 and newer don't contain the find_element_by_xpath method.

> voting_grid = soup.find('table', {'class': 'scoreboard_table'})

The new markup doesn't contain `'div', {'id': 'voting_grid'}`.

> points_cols = cols[4:-1]

The new markup now contains an additional empty column at the end that should be ignored.